### PR TITLE
Update to release 1.2.25 and add AppImage

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,22 +344,20 @@
       <div class="col-lg-4 whitecol p-1 p-lg-5">
         <a class="anchor" id="download"></a>
       <h1 class="text-center">Downloads</h1>
-      <h4 class="text-center">Current version: 1.2.24</h4>
-      <h6 class="text-center">Release date: 2026.07.16</h6>
+      <h4 class="text-center">Current version: 1.2.25</h4>
+      <h6 class="text-center">Release date: 2026.07.25</h6>
 
       <div id="accordionDownload" class="accordion accordion-flush bg-transparent">
         <div class="accordion-item bg-transparent ">
           <h2 class="accordion-header bg-transparent" id="flush-headingOne">
-            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse"
-              data-bs-target="#flush-collapseOne" aria-expanded="false" aria-controls="flush-collapseOne">
+            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseOne" aria-expanded="false" aria-controls="flush-collapseOne">
               <img src="pictures/source-32x32.png" class="accordionLogo" alt="source" /> Source
             </button>
           </h2>
-          <div id="flush-collapseOne" class="accordion-collapse collapse bg-transparent"
-            aria-labelledby="flush-headingOne" data-bs-parent="#accordionDownload">
+          <div id="flush-collapseOne" class="accordion-collapse collapse bg-transparent" aria-labelledby="flush-headingOne" data-bs-parent="#accordionDownload">
             <div class="accordion-body bg-transparent">
               <div class="list-group-flush bg-transparent">
-                <a href="https://files.strawberrymusicplayer.org/strawberry-1.2.24.tar.xz"
+                <a href="https://files.strawberrymusicplayer.org/strawberry-1.2.25.tar.xz"
                   class="list-group-item bg-transparent">LZMA compressed source</a>
               </div>
             </div>
@@ -368,17 +366,15 @@
 
         <div class="accordion-item bg-transparent">
           <h2 class="accordion-header bg-transparent" id="flush-headingTwo">
-            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse"
-              data-bs-target="#flush-collapseTwo" aria-expanded="false" aria-controls="flush-collapseTwo">
+            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseTwo" aria-expanded="false" aria-controls="flush-collapseTwo">
               <img src="pictures/fedora-32x32.png" class="accordionLogo" alt="Fedora" />Fedora
             </button>
           </h2>
-          <div id="flush-collapseTwo" class="accordion-collapse collapse bg-transparent"
-            aria-labelledby="flush-headingTwo" data-bs-parent="#accordionDownload">
+          <div id="flush-collapseTwo" class="accordion-collapse collapse bg-transparent" aria-labelledby="flush-headingTwo" data-bs-parent="#accordionDownload">
             <div class="accordion-body bg-transparent">
               <div class="list-group-flush bg-transparent">
-                <a href="https://files.strawberrymusicplayer.org/strawberry-1.2.24-1.fc43.x86_64.rpm" class="list-group-item bg-transparent">Fedora 43 (x86_64)</a>
-                <a href="https://files.strawberrymusicplayer.org/strawberry-1.2.24-1.fc44.x86_64.rpm" class="list-group-item bg-transparent">Fedora 44 (x86_64)</a>
+                <a href="https://files.strawberrymusicplayer.org/strawberry-1.2.25-1.fc43.x86_64.rpm" class="list-group-item bg-transparent">Fedora 43 (x86_64)</a>
+                <a href="https://files.strawberrymusicplayer.org/strawberry-1.2.25-1.fc44.x86_64.rpm" class="list-group-item bg-transparent">Fedora 44 (x86_64)</a>
               </div>
             </div>
           </div>
@@ -386,16 +382,14 @@
 
         <div class="accordion-item bg-transparent">
           <h2 class="accordion-header bg-transparent" id="flush-headingThree">
-            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse"
-              data-bs-target="#flush-collapseThree" aria-expanded="false" aria-controls="flush-collapseThree">
+            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseThree" aria-expanded="false" aria-controls="flush-collapseThree">
               <img src="pictures/mageia-32x32.png" class="accordionLogo" alt="Mageia" />Mageia
             </button>
           </h2>
-          <div id="flush-collapseThree" class="accordion-collapse collapse bg-transparent"
-            aria-labelledby="flush-headingThree" data-bs-parent="#accordionDownload">
+          <div id="flush-collapseThree" class="accordion-collapse collapse bg-transparent" aria-labelledby="flush-headingThree" data-bs-parent="#accordionDownload">
             <div class="accordion-body bg-transparent">
               <div class="list-group-flush bg-transparent">
-                <a href="https://files.strawberrymusicplayer.org/strawberry-1.2.24-1.mga9.x86_64.rpm" class="list-group-item bg-transparent">Mageia 9 (x86_64)</a>
+                <a href="https://files.strawberrymusicplayer.org/strawberry-1.2.25-1.mga9.x86_64.rpm" class="list-group-item bg-transparent">Mageia 9 (x86_64)</a>
               </div>
             </div>
           </div>
@@ -403,16 +397,14 @@
 
         <div class="accordion-item bg-transparent">
           <h2 class="accordion-header bg-transparent" id="flush-headingFour">
-            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse"
-              data-bs-target="#flush-collapseFour" aria-expanded="false" aria-controls="flush-collapseFour">
+            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseFour" aria-expanded="false" aria-controls="flush-collapseFour">
               <img src="pictures/opensuse-32x32.png" class="accordionLogo" alt="openSUSE" />openSUSE
             </button>
           </h2>
-          <div id="flush-collapseFour" class="accordion-collapse collapse  bg-transparent"
-            aria-labelledby="flush-headingFour" data-bs-parent="#accordionDownload">
+          <div id="flush-collapseFour" class="accordion-collapse collapse  bg-transparent" aria-labelledby="flush-headingFour" data-bs-parent="#accordionDownload">
             <div class="accordion-body bg-transparent">
               <div class="list-group-flush bg-transparent">
-                <a href="https://files.strawberrymusicplayer.org/strawberry-1.2.24-1.lp160.x86_64.rpm" class="list-group-item bg-transparent">openSUSE Leap 16.0 (x86_64)</a>
+                <a href="https://files.strawberrymusicplayer.org/strawberry-1.2.25-1.lp160.x86_64.rpm" class="list-group-item bg-transparent">openSUSE Leap 16.0 (x86_64)</a>
               </div>
             </div>
           </div>
@@ -420,18 +412,16 @@
 
         <div class="accordion-item bg-transparent">
           <h2 class="accordion-header bg-transparent" id="flush-headingFive">
-            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse"
-              data-bs-target="#flush-collapseFive" aria-expanded="false" aria-controls="flush-collapseFive">
+            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseFive" aria-expanded="false" aria-controls="flush-collapseFive">
               <img src="pictures/debian-32x32.png" class="accordionLogo" alt="Debian" />Debian
             </button>
           </h2>
-          <div id="flush-collapseFive" class="accordion-collapse collapse bg-transparent"
-            aria-labelledby="flush-headingFive" data-bs-parent="#accordionDownload">
+          <div id="flush-collapseFive" class="accordion-collapse collapse bg-transparent" aria-labelledby="flush-headingFive" data-bs-parent="#accordionDownload">
             <div class="accordion-body">
               <div class="list-group-flush">
-                <a href="https://files.strawberrymusicplayer.org/strawberry_1.2.24-bookworm_amd64.deb" class="list-group-item bg-transparent">Debian 12 "Bookworm" (x86_64)</a>
-                <a href="https://files.strawberrymusicplayer.org/strawberry_1.2.24-trixie_amd64.deb" class="list-group-item bg-transparent">Debian 13 "Trixie" (x86_64)</a>
-                <a href="https://files.strawberrymusicplayer.org/strawberry_1.2.24-forky_amd64.deb" class="list-group-item bg-transparent">Debian 14 "Forky" (x86_64)</a>
+                <a href="https://files.strawberrymusicplayer.org/strawberry_1.2.25-bookworm_amd64.deb" class="list-group-item bg-transparent">Debian 12 "Bookworm" (x86_64)</a>
+                <a href="https://files.strawberrymusicplayer.org/strawberry_1.2.25-trixie_amd64.deb" class="list-group-item bg-transparent">Debian 13 "Trixie" (x86_64)</a>
+                <a href="https://files.strawberrymusicplayer.org/strawberry_1.2.25-forky_amd64.deb" class="list-group-item bg-transparent">Debian 14 "Forky" (x86_64)</a>
               </div>
             </div>
           </div>
@@ -439,18 +429,16 @@
 
         <div class="accordion-item bg-transparent">
           <h2 class="accordion-header bg-transparent" id="flush-headingSix">
-            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse"
-              data-bs-target="#flush-collapseSix" aria-expanded="false" aria-controls="flush-collapseSix">
+            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseSix" aria-expanded="false" aria-controls="flush-collapseSix">
               <img src="pictures/ubuntu-32x32.png" class="accordionLogo" alt="Ubuntu" />Ubuntu
             </button>
           </h2>
-          <div id="flush-collapseSix" class="accordion-collapse collapse bg-transparent"
-            aria-labelledby="flush-headingSix" data-bs-parent="#accordionDownload">
+          <div id="flush-collapseSix" class="accordion-collapse collapse bg-transparent" aria-labelledby="flush-headingSix" data-bs-parent="#accordionDownload">
             <div class="accordion-body bg-transparent">
               <div class="list-group-flush bg-transparent">
-                <a href="https://files.strawberrymusicplayer.org/strawberry_1.2.24-noble_amd64.deb" class="list-group-item bg-transparent">Ubuntu 24.04 "Noble" (x86_64)</a>
-                <a href="https://files.strawberrymusicplayer.org/strawberry_1.2.24-questing_amd64.deb" class="list-group-item bg-transparent">Ubuntu 25.10 "Questing" (x86_64)</a>
-                <a href="https://files.strawberrymusicplayer.org/strawberry_1.2.24-resolute_amd64.deb" class="list-group-item bg-transparent">Ubuntu 26.04 "Resolute" (x86_64)</a>
+                <a href="https://files.strawberrymusicplayer.org/strawberry_1.2.25-noble_amd64.deb" class="list-group-item bg-transparent">Ubuntu 24.04 "Noble" (x86_64)</a>
+                <a href="https://files.strawberrymusicplayer.org/strawberry_1.2.25-questing_amd64.deb" class="list-group-item bg-transparent">Ubuntu 25.10 "Questing" (x86_64)</a>
+                <a href="https://files.strawberrymusicplayer.org/strawberry_1.2.25-resolute_amd64.deb" class="list-group-item bg-transparent">Ubuntu 26.04 "Resolute" (x86_64)</a>
               </div>
             </div>
           </div>
@@ -458,17 +446,14 @@
 
         <div class="accordion-item bg-transparent">
           <h2 class="accordion-header bg-transparent" id="flush-headingSeven">
-            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse"
-              data-bs-target="#flush-collapseSeven" aria-expanded="false" aria-controls="flush-collapseSeven">
-              <img src="pictures/macos-32x32.png" class="accordionLogo" alt="macOS" />macOS
+            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseSeven" aria-expanded="false" aria-controls="flush-collapseSeven">
+              <img src="pictures/appimage-32x30.png" class="accordionLogo" alt="AppImage" />AppImage
             </button>
           </h2>
-          <div id="flush-collapseSeven" class="accordion-collapse collapse bg-transparent"
-            aria-labelledby="flush-headingSeven" data-bs-parent="#accordionDownload">
+          <div id="flush-collapseSeven" class="accordion-collapse collapse bg-transparent" aria-labelledby="flush-headingSeven" data-bs-parent="#accordionDownload">
             <div class="accordion-body bg-transparent">
               <div class="list-group-flush">
-                <a href="https://www.patreon.com/posts/strawberry-1-2-164032938" class="list-group-item bg-transparent">macOS 14 (Sonoma) or higher (x86_64)</a>
-                <a href="https://www.patreon.com/posts/strawberry-1-2-164032938" class="list-group-item bg-transparent">macOS 14 (Sonoma) or higher (arm64)</a>
+                <a href="https://www.patreon.com/posts/strawberry-1-2-164844310" class="list-group-item bg-transparent">Linux AppImage (x86_64)</a>
               </div>
             </div>
           </div>
@@ -476,17 +461,32 @@
 
         <div class="accordion-item bg-transparent">
           <h2 class="accordion-header bg-transparent" id="flush-headingEighth">
-            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse"
-              data-bs-target="#flush-collapseEighth" aria-expanded="false" aria-controls="flush-collapseEighth">
-              <img src="pictures/windows-32x32.png" class="accordionLogo" alt="Windows" /> Windows
+            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseEighth" aria-expanded="false" aria-controls="flush-collapseEighth">
+              <img src="pictures/macos-32x32.png" class="accordionLogo" alt="macOS" />macOS
             </button>
           </h2>
           <div id="flush-collapseEighth" class="accordion-collapse collapse bg-transparent" aria-labelledby="flush-headingEighth" data-bs-parent="#accordionDownload">
             <div class="accordion-body bg-transparent">
               <div class="list-group-flush">
-                <a href="https://www.patreon.com/posts/strawberry-1-2-164032938" class="list-group-item bg-transparent">Windows 10 or higher (MSVC x64)</a>
-                <a href="https://www.patreon.com/posts/strawberry-1-2-164032938" class="list-group-item bg-transparent">Windows 11 or higher (MSVC arm64)</a>
-                <a href="https://www.patreon.com/posts/strawberry-1-2-164032938" class="list-group-item bg-transparent">Windows 10 or higher (MinGW x64)</a>
+                <a href="https://www.patreon.com/posts/strawberry-1-2-164844310" class="list-group-item bg-transparent">macOS 14 (Sonoma) or higher (x86_64)</a>
+                <a href="https://www.patreon.com/posts/strawberry-1-2-164844310" class="list-group-item bg-transparent">macOS 14 (Sonoma) or higher (arm64)</a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="accordion-item bg-transparent">
+          <h2 class="accordion-header bg-transparent" id="flush-headingNine">
+            <button class="accordion-button collapsed bg-transparent" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapseNine" aria-expanded="false" aria-controls="flush-collapseNine">
+              <img src="pictures/windows-32x32.png" class="accordionLogo" alt="Windows" /> Windows
+            </button>
+          </h2>
+          <div id="flush-collapseNine" class="accordion-collapse collapse bg-transparent" aria-labelledby="flush-headingNine" data-bs-parent="#accordionDownload">
+            <div class="accordion-body bg-transparent">
+              <div class="list-group-flush">
+                <a href="https://www.patreon.com/posts/strawberry-1-2-164844310" class="list-group-item bg-transparent">Windows 10 or higher (MSVC x64)</a>
+                <a href="https://www.patreon.com/posts/strawberry-1-2-164844310" class="list-group-item bg-transparent">Windows 11 or higher (MSVC arm64)</a>
+                <a href="https://www.patreon.com/posts/strawberry-1-2-164844310" class="list-group-item bg-transparent">Windows 10 or higher (MinGW x64)</a>
               </div>
             </div>
           </div>

--- a/sparkle-macos-arm64
+++ b/sparkle-macos-arm64
@@ -5,12 +5,12 @@
         <link>http://www.strawberrymusicplayer.org/</link>
         <description>Strawberry Music Player</description>
         <item>
-            <title>1.2.24</title>
-            <sparkle:version>1.2.24</sparkle:version>
-            <sparkle:shortVersionString>1.2.24</sparkle:shortVersionString>
+            <title>1.2.25</title>
+            <sparkle:version>1.2.25</sparkle:version>
+            <sparkle:shortVersionString>1.2.25</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
-            <link>https://www.patreon.com/posts/strawberry-1-2-164032938</link>
-            <sparkle:releaseNotesLink>https://raw.githubusercontent.com/strawberrymusicplayer/strawberry/1.2.24/Changelog</sparkle:releaseNotesLink>
+            <link>https://www.patreon.com/posts/strawberry-1-2-164844310</link>
+            <sparkle:releaseNotesLink>https://raw.githubusercontent.com/strawberrymusicplayer/strawberry/1.2.25/Changelog</sparkle:releaseNotesLink>
         </item>
     </channel>
 </rss>

--- a/sparkle-macos-x86_64
+++ b/sparkle-macos-x86_64
@@ -5,12 +5,12 @@
         <link>http://www.strawberrymusicplayer.org/</link>
         <description>Strawberry Music Player</description>
         <item>
-            <title>1.2.24</title>
-            <sparkle:version>1.2.24</sparkle:version>
-            <sparkle:shortVersionString>1.2.24</sparkle:shortVersionString>
+            <title>1.2.25</title>
+            <sparkle:version>1.2.25</sparkle:version>
+            <sparkle:shortVersionString>1.2.25</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>
-            <link>https://www.patreon.com/posts/strawberry-1-2-164032938</link>
-            <sparkle:releaseNotesLink>https://raw.githubusercontent.com/strawberrymusicplayer/strawberry/1.2.24/Changelog</sparkle:releaseNotesLink>
+            <link>https://www.patreon.com/posts/strawberry-1-2-164844310</link>
+            <sparkle:releaseNotesLink>https://raw.githubusercontent.com/strawberrymusicplayer/strawberry/1.2.25/Changelog</sparkle:releaseNotesLink>
         </item>
     </channel>
 </rss>

--- a/sparkle-windows-mingw-x64
+++ b/sparkle-windows-mingw-x64
@@ -7,11 +7,11 @@
   <language>en</language>
 
   <item>
-    <title>Strawberry 1.2.24</title>
+    <title>Strawberry 1.2.25</title>
     <sparkle:releaseNotesLink>
-      https://raw.githubusercontent.com/strawberrymusicplayer/strawberry/1.2.24/Changelog
+      https://raw.githubusercontent.com/strawberrymusicplayer/strawberry/1.2.25/Changelog
     </sparkle:releaseNotesLink>
-    <enclosure url="https://www.patreon.com/posts/strawberry-1-2-164032938" sparkle:version="1.2.24" />
+    <enclosure url="https://www.patreon.com/posts/strawberry-1-2-164844310" sparkle:version="1.2.25" />
   </item>
 
 </channel>

--- a/sparkle-windows-msvc-arm64
+++ b/sparkle-windows-msvc-arm64
@@ -7,11 +7,11 @@
   <language>en</language>
 
   <item>
-    <title>Strawberry 1.2.24</title>
+    <title>Strawberry 1.2.25</title>
     <sparkle:releaseNotesLink>
-      https://raw.githubusercontent.com/strawberrymusicplayer/strawberry/1.2.24/Changelog
+      https://raw.githubusercontent.com/strawberrymusicplayer/strawberry/1.2.25/Changelog
     </sparkle:releaseNotesLink>
-    <enclosure url="https://www.patreon.com/posts/strawberry-1-2-164032938" sparkle:version="1.2.24" />
+    <enclosure url="https://www.patreon.com/posts/strawberry-1-2-164844310" sparkle:version="1.2.25" />
   </item>
 
 </channel>

--- a/sparkle-windows-msvc-x64
+++ b/sparkle-windows-msvc-x64
@@ -7,11 +7,11 @@
   <language>en</language>
 
   <item>
-    <title>Strawberry 1.2.24</title>
+    <title>Strawberry 1.2.25</title>
     <sparkle:releaseNotesLink>
-      https://raw.githubusercontent.com/strawberrymusicplayer/strawberry/1.2.24/Changelog
+      https://raw.githubusercontent.com/strawberrymusicplayer/strawberry/1.2.25/Changelog
     </sparkle:releaseNotesLink>
-    <enclosure url="https://www.patreon.com/posts/strawberry-1-2-164032938" sparkle:version="1.2.24" />
+    <enclosure url="https://www.patreon.com/posts/strawberry-1-2-164844310" sparkle:version="1.2.25" />
   </item>
 
 </channel>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added download availability for Strawberry 1.2.25 across supported platforms, including AppImage.
  - Updated macOS and Windows download options for the latest release.

- **Updates**
  - Updated release feeds to advertise version 1.2.25.
  - Refreshed release notes and download links for all supported macOS and Windows architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->